### PR TITLE
Switch to a new User Pool which has MFA setup correctly

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ provider:
   runtime: java17
   environment:
     COGNITO_REGION: "us-east-1"
-    COGNITO_USER_POOL: "us-east-1_jKQHCtx7s"
+    COGNITO_USER_POOL: "us-east-1_AZyvZQdFN"
     PATH_PARAMETER_GROUP_NAME: "groupName"
     # Get all secret key details from SSM
     KEY_PRIVATE_EXPONENT: ${ssm:custom-aws-idp-private-key-private-exponent}


### PR DESCRIPTION
It turns out that if you try to allow SMS MFA to be configured automatically when you create a User Pool, then the User Pool will have "phone" as one of the required user attributes, and it becomes impossible to avoid SMS-based MFA, if e.g. you wanted to use Authenticator App-based MFA instead.

I created a new User Pool which had Authenticator App-based MFA configured during User Pool creation so that "phone" is no longer a required user attribute, I then added SMS-based MFA after creation, and now the new User Pool should have MFA correctly setup for all users going forward. We just need to update this hard-coded constant to match.