### PR TITLE
Try to use the Dependency Submission API to get Dependabot Alerts working

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,22 @@
+name: Dependency Submission API calls for Dependabot
+on:
+  push:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Dependencies
+    runs-on: ubuntu-latest
+    permissions: # The Dependency Submission API requires write permission
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Submit dependencies
+        uses: mikepenz/gradle-dependency-submission@v0.9.1
+        with:
+          use-gradlew: true
+          gradle-build-module: ":app"


### PR DESCRIPTION
GitHub support says that the log4j vulnerabilities are not being flagged because Gradle isn't supported and dependencies need to be sent [using the Dependency Submission API](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api). They link to [this custom action](https://github.com/marketplace/actions/gradle-dependency-submission) and after checking the docs and a few implementations, I think this is how it should be configured. But I won't really know until I commit this to `main`.