### PR TITLE
Add permission for dependency submission

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -31,3 +31,5 @@ jobs:
         with:
           arguments: build
           dependency-graph: generate-and-submit
+    permissions:
+      contents: write


### PR DESCRIPTION
Merging the AWS version bump did not submit the dependencies correctly, checking the logs, I saw:
```
      Warning: Failed to submit dependency graph dependency-graph-reports/java_ci_with_gradle-build.json.
      HttpError: Resource not accessible by integration
      Please ensure that the 'contents: write' permission is available for the workflow job.
```

This PR should add that permission.