### PR TITLE
Remove keycloakAdapterCore, add BouncyCastle and Jetbrains (for @VisibleForTesting), bump to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,15 @@ dependencies {
         libs.softwareAmazonAwssdk.ssm,
         // For SAML generation, from Keycloak
         libs.orgKecloak.keycloakSamlCore,
-        libs.orgKecloak.keycloakAdapterCore,
         libs.orgKecloak.keycloakServices,
+        libs.orgBouncycastle.bcprovJdk18on,
+        libs.orgBouncycastle.bcpkixJdk18on
     )
     implementation(
         libs.orgApacheLoggingLog4j.log4jSlf4j2Impl,
         libs.orgApacheLoggingLog4j.log4jCore,
-        libs.orgApacheLoggingLog4j.log4jApi
+        libs.orgApacheLoggingLog4j.log4jApi,
+        libs.orgJetbrains.annotations
     )
     runtimeOnly libs.comAmazonaws.awsLambdaJavaLog4j2
     testImplementation(
@@ -74,6 +76,6 @@ tasks.register('buildZip', Zip) {
 build.dependsOn buildZip
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ keycloakVersion = "24.0.4"
 amazonSoftwareVersion = "2.25.49"
 junitJupiterVersion = "5.10.2"
 apacheLoggingVersion = "2.23.1"
+bouncyCastleVersion = "1.78.1"
 
 [libraries]
 comAmazonaws-awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
@@ -10,8 +11,9 @@ softwareAmazonAwssdk-cognitoidentityprovider = { group = "software.amazon.awssdk
 comFasterxmlJacksonDataformat-jacksonDataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.1"
 softwareAmazonAwssdk-ssm = { group = "software.amazon.awssdk", name = "ssm", version.ref = "amazonSoftwareVersion" }
 orgKecloak-keycloakSamlCore = { group = "org.keycloak", name = "keycloak-saml-core", version.ref = "keycloakVersion" }
-orgKecloak-keycloakAdapterCore = { group = "org.keycloak", name = "keycloak-adapter-core", version.ref = "keycloakVersion" }
 orgKecloak-keycloakServices = { group = "org.keycloak", name = "keycloak-services", version.ref = "keycloakVersion" }
+orgBouncycastle-bcprovJdk18on = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncyCastleVersion" }
+orgBouncycastle-bcpkixJdk18on = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncyCastleVersion" }
 orgApacheLoggingLog4j-log4jSlf4j2Impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "apacheLoggingVersion" }
 orgApacheLoggingLog4j-log4jCore = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "apacheLoggingVersion" }
 orgApacheLoggingLog4j-log4jApi = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "apacheLoggingVersion" }
@@ -22,3 +24,4 @@ orgJunitJupiter-junitJupiterParams = { group = "org.junit.jupiter", name = "juni
 ukOrgWebcompare-systemStubsJupiter = "uk.org.webcompere:system-stubs-jupiter:2.1.6"
 orgMockito-mockitoCore = "org.mockito:mockito-core:5.11.0"
 orgJunitPlatform-junitPlatformLauncher = "org.junit.platform:junit-platform-launcher:1.11.0-M2"
+orgJetbrains-annotations = "org.jetbrains:annotations:24.1.0"

--- a/src/main/java/gov/nj/innovation/customAwsIdp/SamlGenerator.java
+++ b/src/main/java/gov/nj/innovation/customAwsIdp/SamlGenerator.java
@@ -1,10 +1,10 @@
 package gov.nj.innovation.customAwsIdp;
 
-import com.google.common.annotations.VisibleForTesting;
 import gov.nj.innovation.customAwsIdp.exception.CustomAwsIdpException;
 import gov.nj.innovation.customAwsIdp.keys.KeysWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.dom.saml.v2.assertion.AttributeType;

--- a/src/main/java/gov/nj/innovation/customAwsIdp/lambda/GetSamlResponseHandler.java
+++ b/src/main/java/gov/nj/innovation/customAwsIdp/lambda/GetSamlResponseHandler.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.google.common.annotations.VisibleForTesting;
 import gov.nj.innovation.customAwsIdp.keys.KeyConstants;
 import gov.nj.innovation.customAwsIdp.keys.KeysWrapper;
 import gov.nj.innovation.customAwsIdp.SamlGenerator;
@@ -17,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.jetbrains.annotations.VisibleForTesting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
 


### PR DESCRIPTION
Jumping straight to Keycloak 25 broke the build. It seems the "keycloakAdapterCore" package was removed.

Simply removing that dependency from this repo showed that we were dependent on it only for transitive dependencies - on Guava and BouncyCastle. I added BouncyCastle as a new dependency, and I replaced Guava with Jetbrains, just for the "VisibleForTesting" annotation.

As well, Keycloak 25 is on Java 17, so I bumped that up too. After everything, our tests pass so it looks like this should be a clean change.